### PR TITLE
Export mock headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(LSAN "Enable leak sanitizer" OFF)
 option(MSAN "Enable memory sanitizer" OFF)
 option(TSAN "Enable thread sanitizer" OFF)
 option(UBSAN "Enable UB sanitizer" OFF)
+option(EXPOSE_MOCKS "Make mocks header files visible for child projects" OFF)
 
 
 ## setup compilation flags

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -20,3 +20,7 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libp2p
     NAMESPACE p2p::
 )
+install(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/test/mock/libp2p
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mock
+)

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,6 +1,6 @@
 include(GNUInstallDirs)
 
-function (libp2p_install targets)
+function(libp2p_install targets)
   install(TARGETS ${targets} EXPORT libp2pConfig
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -20,7 +20,9 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/libp2p
     NAMESPACE p2p::
 )
-install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/test/mock/libp2p
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mock
-)
+if(EXPOSE_MOCKS)
+  install(
+      DIRECTORY ${CMAKE_SOURCE_DIR}/test/mock/libp2p
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/mock
+  )
+endif()


### PR DESCRIPTION
Mocks can be used in other projects to test libp2p-related code.