### PR TITLE
Fixed build issues with uninitialized local variables.

### DIFF
--- a/src/crypto/crypto_provider/crypto_provider_impl.cpp
+++ b/src/crypto/crypto_provider/crypto_provider_impl.cpp
@@ -325,8 +325,8 @@ namespace libp2p::crypto {
   outcome::result<EphemeralKeyPair>
   CryptoProviderImpl::generateEphemeralKeyPair(common::CurveType curve) const {
     const auto FAILED{KeyGeneratorError::KEY_GENERATION_FAILED};
-    int nid;
-    size_t private_key_length_in_bytes;
+    int nid = 0;
+    size_t private_key_length_in_bytes = 0;
     switch (curve) {
       case common::CurveType::P256:
         nid = NID_X9_62_prime256v1;
@@ -536,8 +536,8 @@ namespace libp2p::crypto {
   CryptoProviderImpl::stretchKey(common::CipherType cipher_type,
                                  common::HashType hash_type,
                                  const Buffer &secret) const {
-    size_t cipher_key_size;
-    size_t iv_size;
+    size_t cipher_key_size = 0;
+    size_t iv_size = 0;
     switch (cipher_type) {
       case common::CipherType::AES128:
         cipher_key_size = 16;

--- a/src/crypto/rsa_provider/rsa_provider_impl.cpp
+++ b/src/crypto/rsa_provider/rsa_provider_impl.cpp
@@ -132,7 +132,7 @@ namespace libp2p::crypto::rsa {
     OUTCOME_TRY(rsa, rsaFromPrivateKey(private_key));
     Hash256 digest = sha256(message);
     Signature signature(RSA_size(rsa.get()));
-    unsigned int signature_size;
+    unsigned int signature_size = 0;
     if (1
         != RSA_sign(NID_sha256, digest.data(), digest.size(), signature.data(),
                     &signature_size, rsa.get())) {

--- a/src/protocol/kademlia/impl/kad_impl.cpp
+++ b/src/protocol/kademlia/impl/kad_impl.cpp
@@ -441,7 +441,7 @@ namespace libp2p::protocol::kademlia {
   };
 
   void KadImpl::getValue(const ContentAddress &key, GetValueResultFunc f) {
-    LocalValueStore::AbsTime ts;
+    LocalValueStore::AbsTime ts = 0;
     auto res = local_store_->getValue(key, ts);
     if (res) {
       // TODO(artem): subscriptions instead of coarse callback API


### PR DESCRIPTION
Current build failed due to uninitialized local variables with 3 files. The build flagged these warnings as errors. A simple change fixed the issue and allowed the build to complete.