### PR TITLE
Add proper dns-resolving

### DIFF
--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -45,6 +45,14 @@ namespace libp2p::transport {
     void resolve(const Tcp::endpoint &endpoint, ResolveCallbackFunc cb);
 
     /**
+     * @brief Resolve service name (DNS).
+     * @param host_name host name to resolve
+     * @param cb callback executed on operation completion.
+     */
+    void resolve(const std::string &host_name, const std::string &port,
+                 ResolveCallbackFunc cb);
+
+    /**
      * @brief Connect to a remote service.
      * @param iterator list of resolved IP addresses of remote service.
      * @param cb callback executed on operation completion.

--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -53,6 +53,15 @@ namespace libp2p::transport {
                  ResolveCallbackFunc cb);
 
     /**
+     * @brief Resolve service name (DNS).
+     * @param protocol is either Tcp::ip4 or Tcp::ip6 protocol
+     * @param host_name host name to resolve
+     * @param cb callback executed on operation completion.
+     */
+    void resolve(const Tcp &protocol, const std::string &host_name,
+                 const std::string &port, ResolveCallbackFunc cb);
+
+    /**
      * @brief Connect to a remote service.
      * @param iterator list of resolved IP addresses of remote service.
      * @param cb callback executed on operation completion.

--- a/include/libp2p/transport/tcp/tcp_util.hpp
+++ b/include/libp2p/transport/tcp/tcp_util.hpp
@@ -12,8 +12,8 @@
 #include <boost/asio.hpp>
 #include <boost/lexical_cast.hpp>
 #include <gsl/span>
-#include <libp2p/outcome/outcome.hpp>
 #include <libp2p/multi/multiaddress.hpp>
+#include <libp2p/outcome/outcome.hpp>
 
 namespace libp2p::transport::detail {
   template <typename T>
@@ -56,7 +56,8 @@ namespace libp2p::transport::detail {
 
   inline bool supportsIpTcp(const multi::Multiaddress &ma) {
     using P = multi::Protocol::Code;
-    return (ma.hasProtocol(P::IP4) || ma.hasProtocol(P::IP6))
+    return (ma.hasProtocol(P::IP4) || ma.hasProtocol(P::IP6)
+            || ma.hasProtocol(P::DNS4) || ma.hasProtocol(P::DNS6))
         && ma.hasProtocol(P::TCP);
   }
 
@@ -68,7 +69,8 @@ namespace libp2p::transport::detail {
     try {
       auto v = ma.getProtocolsWithValues();
       auto it = v.begin();
-      if (!(it->first.code == P::IP4 || it->first.code == P::IP6)) {
+      if (!(it->first.code == P::IP4 || it->first.code == P::IP6
+            || it->first.code == P::DNS4 || it->first.code == P::DNS6)) {
         return std::errc::address_family_not_supported;
       }
 

--- a/include/libp2p/transport/tcp/tcp_util.hpp
+++ b/include/libp2p/transport/tcp/tcp_util.hpp
@@ -67,7 +67,7 @@ namespace libp2p::transport::detail {
   }
 
   // Obtain host and port strings from provided address
-  inline std::pair<std::string, std::string> getHostAndPort(
+  inline std::pair<std::string, std::string> getHostAndTcpPort(
       const multi::Multiaddress &address) {
     auto v = address.getProtocolsWithValues();
 

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -75,6 +75,18 @@ namespace libp2p::transport {
         });
   }
 
+  void TcpConnection::resolve(const TcpConnection::Tcp &protocol,
+                              const std::string &host_name,
+                              const std::string &port,
+                              TcpConnection::ResolveCallbackFunc cb) {
+    auto resolver = std::make_shared<Tcp::resolver>(context_);
+    resolver->async_resolve(
+        protocol, host_name, port,
+        [resolver, cb{std::move(cb)}](const ErrorCode &ec, auto &&iterator) {
+          cb(ec, std::forward<decltype(iterator)>(iterator));
+        });
+  }
+
   void TcpConnection::connect(
       const TcpConnection::ResolverResultsType &iterator,
       TcpConnection::ConnectCallbackFunc cb) {

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -64,6 +64,17 @@ namespace libp2p::transport {
         });
   }
 
+  void TcpConnection::resolve(const std::string &host_name,
+                              const std::string &port,
+                              TcpConnection::ResolveCallbackFunc cb) {
+    auto resolver = std::make_shared<Tcp::resolver>(context_);
+    resolver->async_resolve(
+        host_name, port,
+        [resolver, cb{std::move(cb)}](const ErrorCode &ec, auto &&iterator) {
+          cb(ec, std::forward<decltype(iterator)>(iterator));
+        });
+  }
+
   void TcpConnection::connect(
       const TcpConnection::ResolverResultsType &iterator,
       TcpConnection::ConnectCallbackFunc cb) {

--- a/src/transport/tcp/tcp_transport.cpp
+++ b/src/transport/tcp/tcp_transport.cpp
@@ -18,7 +18,7 @@ namespace libp2p::transport {
 
     auto conn = std::make_shared<TcpConnection>(*context_);
 
-    auto [host, port] = detail::getHostAndPort(address);
+    auto [host, port] = detail::getHostAndTcpPort(address);
 
     auto connect = [self{shared_from_this()}, conn, handler{std::move(handler)},
                     remoteId](auto ec, auto r) mutable {

--- a/src/transport/tcp/tcp_transport.cpp
+++ b/src/transport/tcp/tcp_transport.cpp
@@ -9,23 +9,6 @@
 
 namespace libp2p::transport {
 
-  // Obtain host and port strings from provided address
-  std::pair<std::string, std::string> getHostAndPort(
-      const multi::Multiaddress &address) {
-    auto v = address.getProtocolsWithValues();
-
-    // get host
-    auto it = v.begin();
-    auto host = it->second;
-
-    // get port
-    it++;
-    BOOST_ASSERT(it->first.code == multi::Protocol::Code::TCP);
-    auto port = it->second;
-
-    return {host, port};
-  }
-
   void TcpTransport::dial(const peer::PeerId &remoteId,
                           multi::Multiaddress address,
                           TransportAdaptor::HandlerFunc handler) {
@@ -35,29 +18,38 @@ namespace libp2p::transport {
 
     auto conn = std::make_shared<TcpConnection>(*context_);
 
-    auto [host, port] = getHostAndPort(address);
+    auto [host, port] = detail::getHostAndPort(address);
 
-    conn->resolve(host, port,
-                  [self{shared_from_this()}, conn, handler{std::move(handler)},
-                   remoteId](auto ec, auto r) mutable {
-                    if (ec) {
-                      return handler(ec);
-                    }
+    auto connect = [self{shared_from_this()}, conn, handler{std::move(handler)},
+                    remoteId](auto ec, auto r) mutable {
+      if (ec) {
+        return handler(ec);
+      }
 
-                    conn->connect(
-                        r,
-                        [self, conn, handler{std::move(handler)}, remoteId](
-                            auto ec, auto &e) mutable {
-                          if (ec) {
-                            return handler(ec);
-                          }
+      conn->connect(r,
+                    [self, conn, handler{std::move(handler)}, remoteId](
+                        auto ec, auto &e) mutable {
+                      if (ec) {
+                        return handler(ec);
+                      }
 
-                          auto session = std::make_shared<UpgraderSession>(
-                              self->upgrader_, std::move(conn), handler);
+                      auto session = std::make_shared<UpgraderSession>(
+                          self->upgrader_, std::move(conn), handler);
 
-                          session->secureOutbound(remoteId);
-                        });
-                  });
+                      session->secureOutbound(remoteId);
+                    });
+    };
+
+    using P = multi::Protocol::Code;
+    switch (detail::getFirstProtocol(address)) {
+      case P::DNS4:
+        return conn->resolve(boost::asio::ip::tcp::v4(), host, port, connect);
+      case P::DNS6:
+        return conn->resolve(boost::asio::ip::tcp::v6(), host, port, connect);
+      default:  // Could be only DNS, IP6 or IP4 as canDial already checked for
+                // that in the beginning of the method
+        return conn->resolve(host, port, connect);
+    }
   }
 
   std::shared_ptr<TransportListener> TcpTransport::createListener(


### PR DESCRIPTION
### Description

Current PR introduces handling of multiaddresses containing dns-address. So that we can handle addresses like `/dns4/p2p.cc3-0.kusama.network/tcp/30100/p2p/QmeCit3Nif4VfNqrEJsdYHZGcKzRCnZvGxg6hha1iNj4mk`

### Example

Run libp2p server: 

`./libp2p_echo_server -insecure`

Run libp2p client:

`./libp2p_echo_client /dns4/localhost/tcp/40010/ipfs/12D3KooWEgUjBV5FJAuBSoNMRYFRHjV7PjZwRQ7b43EKX9g7D6xV`