### PR TITLE
Bump hunter version

### DIFF
--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -31,7 +31,7 @@ set(
 include(${CMAKE_CURRENT_LIST_DIR}/HunterGate.cmake)
 
 HunterGate(
-    URL "https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.253-soramitsu1.tar.gz"
-    SHA1 2b8e570843e8b6a0c96d70a8d312dda425fa52a9
+    URL "https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.254-soramitsu1.tar.gz"
+    SHA1 7819e7dd14f58b6df2fd7f2bc835265d60add3f5
     LOCAL
 )


### PR DESCRIPTION
## Description

Boost version 1.72.0-p0 from Hunter had an issue compiling with the Mac Os's Command line tools version 11.4.

Original hunter has the fix represented by the boost version 1.72.0-p1. Current PR bumps hunter to the version containing this boost version.

Therefore an issue compiling boost on the latest Mac OS should be resolved.

Pull request introducing latest boost version to our hunter: https://github.com/soramitsu/soramitsu-hunter/pull/5